### PR TITLE
Truncate the failure cause if over the result size limit

### DIFF
--- a/stefuna/util.py
+++ b/stefuna/util.py
@@ -21,5 +21,5 @@ def configure_logger(name, log_format, handler):
 
 def safe_cause(cause):
     if len(cause) > SFN_LIMITS['CAUSE_SIZE']:
-        return cause[:SFN_LIMITS['CAUSE_SIZE']-len(ELLIPSIS)] + ELLIPSIS
+        return cause[:SFN_LIMITS['CAUSE_SIZE'] - len(ELLIPSIS)] + ELLIPSIS
     return cause

--- a/stefuna/util.py
+++ b/stefuna/util.py
@@ -1,6 +1,13 @@
 import logging
 
 
+SFN_LIMITS = {
+    'CAUSE_SIZE': 32768
+}
+
+ELLIPSIS = '...'
+
+
 # Configure a logger with a format and handler.
 def configure_logger(name, log_format, handler):
     logger = logging.getLogger(name)
@@ -10,3 +17,9 @@ def configure_logger(name, log_format, handler):
     logger.addHandler(handler)
     logger.propagate = False
     return logger
+
+
+def safe_cause(cause):
+    if len(cause) > SFN_LIMITS['CAUSE_SIZE']:
+        return cause[:SFN_LIMITS['CAUSE_SIZE']-len(ELLIPSIS)] + ELLIPSIS
+    return cause

--- a/stefuna/worker.py
+++ b/stefuna/worker.py
@@ -7,6 +7,7 @@ from botocore.exceptions import ClientError
 import signal
 from abc import ABCMeta, abstractmethod
 from threading import Thread, Lock
+from .util import safe_cause
 
 
 logger = logging.getLogger('stefuna')
@@ -156,7 +157,7 @@ class Worker(object):
             self.sf_client.send_task_failure(
                 taskToken=self.task_token,
                 error=error,
-                cause=cause
+                cause=safe_cause(cause)
             )
         except Exception:
             # We log the error and the task state will eventually timeout


### PR DESCRIPTION
This can happen when an exception with a really long callstack and /or message is raised by a worker. This makes the `send_task_failure` api call fail, therefore the execution of the task hangs forever (unless a timeout was set). 

Exception before the fix:
```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/stefuna/worker.py", line 160, in send_task_failure
    cause=safe_cause(cause)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 314, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 612, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the SendTaskFailure operation: 1 validation error detected: Value at 'cause' failed to satisfy constraint: Member must have length less than or equal to 32768
```

I've tested this branch on a real world exemple raising a really large exception and I can confirm that this is working. I've even played around with the limit to test different use cases, for exemple: increasing it by one will trigger the error above.